### PR TITLE
Se actualizaron todas las sentencias con el parametro unaccent()

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "typeorm": "ts-node -r tsconfig-paths/register ./node_modules/.bin/typeorm",
-    "migration:generate": "npm run typeorm migration:generate -- -d ./typeorm.config.ts",
+    "migration:create": "npm run typeorm -- migration:create",
     "migration:run": "npm run typeorm migration:run -- -d typeorm.config.ts",
     "migration:revert": "npm run typeorm migration:revert -- -d typeorm.config.ts",
     "schema:log": "npm run typeorm -- schema:log -d ./typeorm.config.ts",

--- a/src/adquisiciones/adquisiciones.service.ts
+++ b/src/adquisiciones/adquisiciones.service.ts
@@ -56,13 +56,13 @@ export class AdquisicionesService {
       ]);
 
     if (q) {
-      queryBuilder.andWhere('usuario.username LIKE :username', {
+      queryBuilder.andWhere("unaccent(usuario.username) ILIKE unaccent(:username)", {
         username: `%${q}%`,
       });
     }
 
     if (filter) {
-      queryBuilder.andWhere('departamento.nombre = :departamento', {
+      queryBuilder.andWhere("unaccent(departamento.nombre) ILIKE unaccent(:departamento)", {
         departamento: `${filter}`,
       });
     }

--- a/src/categorias/categorias.service.ts
+++ b/src/categorias/categorias.service.ts
@@ -21,7 +21,7 @@ export class CategoriasService {
       .select(['categoria.id', 'categoria.nombre']);
 
     if (q) {
-      queryBuilder.andWhere('categoria.nombre ILIKE :nombre', {
+      queryBuilder.andWhere("unaccent(categoria.nombre) ILIKE unaccent(:nombre)", {
         nombre: `%${q}%`,
       });
     }

--- a/src/departamentos/departamentos.service.ts
+++ b/src/departamentos/departamentos.service.ts
@@ -40,7 +40,7 @@ export class DepartamentosService {
       .where('departamento.is_active = :isActive', { isActive: true });
 
     if (q) {
-      queryBuilder.andWhere('departamento.nombre ILIKE :nombre', {
+      queryBuilder.andWhere("unaccent(departamento.nombre) ILIKE unaccent(:nombre)", {
         nombre: `%${q}%`,
       });
     }

--- a/src/examenes/examenes.service.ts
+++ b/src/examenes/examenes.service.ts
@@ -62,7 +62,7 @@ export class ExamenesService {
       .where('examen.is_active = :isActive', { isActive: true });
 
     if (q) {
-      queryBuilder.andWhere('examen.nombre ILIKE :nombre', {
+      queryBuilder.andWhere("unaccent(examen.nombre) ILIKE unaccent(:nombre)", {
         nombre: `%${q}%`,
       });
     }

--- a/src/insumo_departamentos/insumo_departamentos.service.ts
+++ b/src/insumo_departamentos/insumo_departamentos.service.ts
@@ -45,11 +45,11 @@ export class InsumoDepartamentosService {
       ]);
 
     if (q) {
-      queryBuilder.andWhere('insumo.nombre LIKE :nombre', { nombre: `%${q}%` });
+      queryBuilder.andWhere("unaccent(insumo.nombre) ILIKE unaccent(:nombre)", { nombre: `%${q}%` });
     }
 
     if (filter) {
-      queryBuilder.andWhere('departamento.nombre = :departamento', {
+      queryBuilder.andWhere("unaccent(departamento.nombre) = unaccent(:departamento)", {
         departamento: `${filter}`,
       });
     }

--- a/src/insumos/insumos.service.ts
+++ b/src/insumos/insumos.service.ts
@@ -59,13 +59,13 @@ export class InsumosService {
 
     if (q) {
       queryBuilder.andWhere(
-        'insumo.nombre ILIKE :nombre OR insumo.codigo ILIKE :codigo',
+        "unaccent(insumo.nombre) ILIKE unaccent(:nombre) OR unaccent(insumo.codigo) ILIKE unaccent(:codigo)",
         { nombre: `%${q}%`, codigo: `%${q}%` },
       );
     }
 
     if (filter) {
-      queryBuilder.andWhere('categoria.nombre = :categoria', {
+      queryBuilder.andWhere("unaccent(categoria.nombre) = unaccent(:categoria)", {
         categoria: filter,
       });
     }
@@ -329,13 +329,13 @@ export class InsumosService {
 
     if (q) {
       queryBuilder.andWhere(
-        'insumo.nombre ILIKE :nombre OR insumo.codigo ILIKE :codigo',
+        "unaccent(insumo.nombre) ILIKE unaccent(:nombre) OR unaccent(insumo.codigo) ILIKE unaccent(:codigo)",
         { nombre: `%${q}%`, codigo: `%${q}%` },
       );
     }
 
     if (filter) {
-      queryBuilder.andWhere('categoria.nombre = :categoria', {
+      queryBuilder.andWhere("unaccent(categoria.nombre) = unaccent(:categoria)", {
         categoria: filter,
       });
     }

--- a/src/migrations/1731621424818-unaccent.ts
+++ b/src/migrations/1731621424818-unaccent.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddUnaccentExtension1730356554381 implements MigrationInterface {
+  name = 'AddUnaccentExtension1730356554381';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Create unaccent extension
+    await queryRunner.query(`CREATE EXTENSION IF NOT EXISTS unaccent;`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Drop unaccent extension
+    await queryRunner.query(`DROP EXTENSION IF EXISTS unaccent;`);
+  }
+}

--- a/src/orden_laboratorios/orden_laboratorios.service.ts
+++ b/src/orden_laboratorios/orden_laboratorios.service.ts
@@ -120,7 +120,7 @@ export class OrdenLaboratoriosService {
     // Aplicar filtro de búsqueda (si se proporciona)
     if (q) {
       queryBuilder.andWhere(
-        'ordenLaboratorio.usuario ILIKE :usuario OR ordenLaboratorio.examen ILIKE :examen',
+        "unaccent(ordenLaboratorio.usuario) ILIKE unaccent(:usuario) OR unaccent(ordenLaboratorio.examen) ILIKE unaccent(:examen)",
         { usuario: `%${q}%`, examen: `%${q}%` },
       );
     }

--- a/src/pacientes/pacientes.service.ts
+++ b/src/pacientes/pacientes.service.ts
@@ -55,7 +55,7 @@ export class PacientesService {
       ]);
 
     if (q) {
-      queryBuilder.andWhere('paciente.nombre ILIKE :nombre OR paciente.cui ILIKE :cui', {
+      queryBuilder.andWhere("unaccent(paciente.nombre) ILIKE unaccent(:nombre) OR paciente.cui ILIKE :cui", {
         nombre: `%${q}%`, cui: `%${q}%` });
     }
 

--- a/src/recetas/recetas.service.ts
+++ b/src/recetas/recetas.service.ts
@@ -103,14 +103,14 @@ export class RecetasService {
 
     if (q) {
       queryBuilder.andWhere(
-        '(user.name ILIKE :name OR paciente.nombre ILIKE :nombre OR paciente.cui ILIKE :cui)',
+        "(unaccent(user.name) ILIKE unaccent(:name) OR unaccent(paciente.nombre) ILIKE unaccent(:nombre) OR paciente.cui ILIKE :cui)",
         { name: `%${q}%`, nombre: `%${q}%`, cui: `%${q}%` },
       );
     }
 
     if (filter) {
       queryBuilder.andWhere(
-        '(user.name = :user OR paciente.nombre = :paciente)',
+        "(unaccent(user.name) = unaccent(:user) OR unaccent(paciente.nombre) = unaccent(:paciente))",
         { user: filter, paciente: filter },
       );
     }

--- a/src/retiros/retiros.service.ts
+++ b/src/retiros/retiros.service.ts
@@ -63,7 +63,7 @@ export class RetirosService {
 
     if (q) {
       queryBuilder.andWhere(
-        '(user.username ILIKE :username OR departamento.nombre ILIKE :departamento)',
+        "(unaccent(user.username) ILIKE unaccent(:username) OR unaccent(departamento.nombre) ILIKE unaccent(:departamento))",
         {
           username: `%${q}%`,
           departamento: `%${q}%`,
@@ -72,7 +72,7 @@ export class RetirosService {
     }
 
     if (filterDepartamento) {
-      queryBuilder.andWhere('departamento.nombre = :departamento', {
+      queryBuilder.andWhere("unaccent(departamento.nombre) = unaccent(:departamento)", {
         departamento: `${filterDepartamento}`,
       });
     }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -45,13 +45,13 @@ export class UsersService {
 
     if (q) {
       queryBuilder.andWhere(
-        '(user.name ILIKE :name OR user.username ILIKE :username OR user.email ILIKE :email)',
+        "(unaccent(user.name) ILIKE unaccent(:name) OR unaccent(user.username) ILIKE unaccent(:username) OR user.email ILIKE :email)",
         { name: `%${q}%`, username: `%${q}%`, email: `%${q}%` },
       );
     }
 
     if (filter) {
-      queryBuilder.andWhere('role.name = :role', { role: `${filter}` });
+      queryBuilder.andWhere("unaccent(role.name) = unaccent(:role)", { role: `${filter}` });
     }
 
     const totalItems = await queryBuilder.getCount();


### PR DESCRIPTION
Se actualizaron las sentencias de los siguientes modulos para validar entradas sensibles mayusculas, tildes y diéresis y volverlas unicamente en minisculas sin ningun caracter especial como mayusculas, tildes o diéresis.

ADQUISICIONES
CATEGORIA
DEPARTAMENTOS
EXAMENES
INSUMO DEPARTAMENTOS
INSUMOS
ORDEN-LABORATORIOS
PACIENTES
RECETAS
RETIROS
USERS

Si no funciona se necesita correr el siguiente comando en la base de datos:
CREATE EXTENSION IF NOT EXISTS unaccent;
